### PR TITLE
Feature: Adicionando suporte para comando db:seed com dados fake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,5 @@ gem "heroicon", "~> 1.0"
 gem "pry", "~> 0.14.2"
 gem 'pry-rails'
 gem 'whenever', require: false
+
+gem "faker", "~> 3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
       dotenv (= 2.8.1)
       railties (>= 3.2)
     erubi (1.12.0)
+    faker (3.2.1)
+      i18n (>= 1.8.11, < 2)
     globalid (1.1.0)
       activesupport (>= 5.0)
     heroicon (1.0.0)
@@ -270,6 +272,7 @@ DEPENDENCIES
   debug
   dockerfile-rails (>= 1.5)
   dotenv-rails
+  faker (~> 3.2)
   heroicon (~> 1.0)
   httparty (~> 0.21.0)
   importmap-rails

--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ Para um guia mais direto com a instalação, recomendo entrar no [gorails](https
 
 Com o `git` instalado, clone o repositório
 
-```shell
+```sh
 
-$ git clone https://github.com/cherryramatisdev/4noobs_tracker.git && cd 4noobs_tracker
+git clone https://github.com/cherryramatisdev/4noobs_tracker.git && cd 4noobs_tracker
 ```
 
 #### Instalando as dependências
 
 Instale todas as dependências executando o seguinte em seu terminal
 
-```shell
+```sh
 bundle install
 ```
 
@@ -37,20 +37,30 @@ bundle install
 
 Parabéns 🎉, você realizou a instalação do projeto. Agora basta iniciar a aplicação
 
-```shell
+```sh
 bundle exec rails server
 ```
 
 #### Fazendo o fetch dos repositórios e issues
 
-Caso a sua página inicial esteja vazia, você pode fazer o fetch de todos os
-repositórios e issues com os seguintes comandos
+Caso a sua página inicial esteja vazia, você tem duas opções para conseguir desenvolver tranquilamente:
 
-**Importante**
+1. Usar mock: Super útil caso você tenha interesse apenas em testar o framework e não quer lidar com configuração de tokens e etc (*Recomendado para iniciantes*).
+2. Usar os comandos `fetch`: Caso você tenha interesse em modificar a logica principal da aplicação, necessita lidar com geração de tokens. (**Caso
+
+##### Usar mock
+
+Para usar o mock é super simples, apenas execute o comando:
+
+```sh
+rails db:seed
+```
+
+##### Usar os comandos fetch
 
 Para conseguir executar esse comandos é necessária a configuração de uma variável de ambiente no projeto com o token do GitHub para que seja possível acessar a API deles. Por favor referencie a [documentação](/docs/3-como-criar-um-token-github.md)
 
-```shell
+```sh
 # Fazendo fetch de todos os repositórios
 $ bundle exec rails fetch:repositories
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,24 @@
 # frozen_string_literal: true
+
+require 'faker'
+
+# Create 10 repositories
+10.times do
+  repository = Repository.create(
+    name: Faker::App.name,
+    owner: Faker::Internet.user_name,
+    url: Faker::Internet.url
+  )
+
+  # Create 2 issues for each repository
+  2.times do
+    Issue.create(
+      title: Faker::Lorem.sentence,
+      url: Faker::Internet.url,
+      state: 'open',
+      assignee: Faker::Internet.user_name,
+      issue_type: 'issues',
+      repository: repository
+    )
+  end
+end


### PR DESCRIPTION
O proposito dessa PR é facilitar a contribuição para pessoas iniciantes no projeto, principalmente para PRs onde só existem melhorias de front-end. A ideia é prover um comando onde a pessoa pode simplesmente conseguir listar a pagina inicial sem precisar lidar com token GitHub.

Também adicionei a sessão no README para facilitar o setup inicial, basicamente a pessoa executa `rails db:seed` e ela consegue uma tela já pronta como mostrado abaixo:

![image](https://github.com/cherryramatisdev/4noobs_tracker/assets/86631177/b4053f43-fade-460f-ae9f-95ab8c8153c1)
