### PR TITLE
Fix: initial configuration related errors

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@ require 'faker'
   repository = Repository.create(
     name: Faker::App.name,
     owner: Faker::Internet.user_name,
-    url: Faker::Internet.url
+    url: Faker::Internet.url,
     technology: Faker::ProgrammingLanguage.name
   )
 

--- a/docs/3-como-criar-um-token-github.md
+++ b/docs/3-como-criar-um-token-github.md
@@ -22,7 +22,7 @@ https://github.com/cherryramatisdev/4noobs_tracker/assets/86631177/f93a96c2-73f0
 5. Agora que você conseguiu copiar o token, crie um arquivo `.env` na pasta do projeto com o seguinte conteudo:
 
 ```
-GH_API_TOKEN=seutokenaqui
+GH_API_KEY=seutokenaqui
 ```
 
 Parabéns! Agora você deve conseguir executar o comandos descritos no [README](/README.md) facilmente.


### PR DESCRIPTION
2 Sugestões de correções a serem implementadas:

* Seeds.rb faltando uma vírgula, e sim, só isso já atrapalhando a execução hahah
* Na documentação sobre como criar um token no github, é mencionada a variável GH_API_TOKEN, mas no ENV.fetch é utilizado GH_API_KEY. Sugiro trocar para GH_API_KEY, pois é como provavelmente está configurado em um possível deploy e nas máquinas locais dos demais contribuidores até agora
    * ```GH_API_TOKEN=seutokenaqui```
    * `gh_token = "Bearer #{ENV.fetch('GH_API_KEY', nil)}"`